### PR TITLE
Fix builtin #27

### DIFF
--- a/includes/shell_var.h
+++ b/includes/shell_var.h
@@ -17,7 +17,7 @@ typedef struct s_env
 }	t_env;
 
 t_list		*init_envlist(void);
-char		**get_environ(void);
+char		**get_environ(t_shell_var *shell_var);
 char		*get_env_value(char *key, t_shell_var *shell_var);
 
 #endif

--- a/src/builtin/builtin_env.c
+++ b/src/builtin/builtin_env.c
@@ -2,10 +2,11 @@
 
 int		builtin_env(t_expression *expression, t_process *process, t_shell_var *shell_var)
 {
-	t_list	*env_list = init_envlist();
 	t_list	*itr;
 
-	itr = env_list;
+	(void)expression;
+	(void)process;
+	itr = shell_var->env_list->next;
 	while (itr)
 	{
 		printf("%s=%s\n", ((t_env *)(itr->content))->key, ((t_env *)(itr->content))->val);

--- a/src/builtin/builtin_export.c
+++ b/src/builtin/builtin_export.c
@@ -1,5 +1,19 @@
 #include "minishell.h"
 
+void	builtin_export_print(t_list *env_list)
+{
+	t_list	*itr;
+
+	itr = env_list->next;
+	while (itr)
+	{
+		printf("declare -x %s=\"%s\"\n", ((t_env *)(itr->content))->key, ((t_env *)(itr->content))->val);
+		// printf("%s", ((t_env *)(itr->content))->key);
+		// printf("=\"%s\"\n", ((t_env *)(itr->content))->val);
+		itr = itr->next;
+	}
+}
+
 static bool validate_args(char *arg)
 {
 	bool valid;
@@ -23,55 +37,47 @@ static bool validate_args(char *arg)
 	return (valid);
 }
 
-int	builtin_export(t_expression *expression, t_process *process, t_shell_var *shell_var)
+bool	set_env_value(char *arg, t_list *env_list)
 {
-	t_list	*env_list = init_envlist();
 	t_list	*itr;
-	char	*arg;
 	char	*key;
 	char	*val;
 	t_env	*env;
 
-	if (ft_lstsize((t_list *)(process->token_list)) == 1)
+	if (!validate_args(arg))
+		return (false);
+	key = ft_strndup(arg, ft_strchr(arg, '=') - arg);
+	val = ft_strdup(ft_strchr(arg, '=') + 1);
+	itr = env_list->next;
+	while (itr)
 	{
-		itr = env_list;
-		while (itr)
+		if (ft_strcmp(((t_env *)(itr->content))->key, key) == 0)
 		{
-			printf("declare -x %s=\"%s\"\n", ((t_env *)(itr->content))->key, ((t_env *)(itr->content))->val);
-			// printf("%s", ((t_env *)(itr->content))->key);
-			// printf("=\"%s\"\n", ((t_env *)(itr->content))->val);
-			itr = itr->next;
+			free(((t_env *)(itr->content))->val);
+			((t_env *)(itr->content))->val = val;
+			return (true);
 		}
+		itr = itr->next;
 	}
+	env = ft_calloc(1, sizeof(t_env));
+	env->key = key;
+	env->val = val;
+	ft_lstadd_back(&env_list, ft_lstnew(env));
+	return (true);
+}
+
+int	builtin_export(t_expression *expression, t_process *process, t_shell_var *shell_var)
+{
+	char	*arg;
+
+	(void)expression;
+	if (ft_lstsize((t_list *)(process->token_list)) == 1)
+		builtin_export_print(shell_var->env_list);
 	else
 	{
 		arg = ((t_token *)(process->token_list->next->content))->str;
-		// 引数のバリデイト
-		if (!validate_args(arg))
+		if (!set_env_value(arg, shell_var->env_list))
 			return (1);
-		// 引数のtoken_listからkeyとvalを取り出す
-		key = ft_strndup(arg, ft_strchr(arg, '=') - arg);
-		val = ft_strdup(ft_strchr(arg, '=') + 1);
-		// env_listにkeyと一致するものがあったら，そのkeyにvalを上書きする
-		itr = env_list;
-		while (itr)
-		{
-			if (ft_strcmp(((t_env *)(itr->content))->key, key) == 0)
-			{
-				free(((t_env *)(itr->content))->val);
-				((t_env *)(itr->content))->val = val;
-				break ;
-			}
-			itr = itr->next;
-		}
-		// なければ，新しくkeyとvalを追加する
-		if (itr == NULL)
-		{
-			env = ft_calloc(1, sizeof(t_env));
-			env->key = key;
-			env->val = val;
-			ft_lstadd_back(&env_list, ft_lstnew(env));
-		}
 	}
 	// printf("called builtin_export\n");
 	return (0);

--- a/src/builtin/builtin_unset.c
+++ b/src/builtin/builtin_unset.c
@@ -2,17 +2,15 @@
 
 int		builtin_unset(t_expression *expression, t_process *process, t_shell_var *shell_var)
 {
-	t_list	*env_list = init_envlist();
-	t_list	head;
 	t_list	*itr;
 	t_list	*next;
 	t_list	*prev;
 	char	*key;
 
+	(void)expression;
 	key = ((t_token *)(process->token_list->next->content))->str;
-	head.next = env_list;
-	prev = &head;
-	itr = env_list;
+	prev = shell_var->env_list;
+	itr = shell_var->env_list->next;
 	while (itr)
 	{
 		next = itr->next;

--- a/src/env/get_env_value.c
+++ b/src/env/get_env_value.c
@@ -4,7 +4,7 @@ char	*get_env_value(char *key, t_shell_var *shell_var)
 {
 	t_list	*itr;
 
-	itr = shell_var->env_list;
+	itr = shell_var->env_list->next;
 	while (itr)
 	{
 		if (ft_strcmp(((t_env *)itr->content)->key, key) == 0)

--- a/src/env/get_environ.c
+++ b/src/env/get_environ.c
@@ -1,16 +1,15 @@
 #include "minishell.h"
 
-char	**get_environ(void)
+char	**get_environ(t_shell_var *shell_var)
 {
-	t_list	*env_list = init_envlist();
 	char	**environ;
 	t_list	*itr;
 	size_t	i;
 	char	*key;
 
 	i = 0;
-	environ = ft_calloc(ft_lstsize(env_list) + 1, sizeof(char *));
-	itr = env_list;
+	environ = ft_calloc(ft_lstsize(shell_var->env_list), sizeof(char *));
+	itr = shell_var->env_list->next;
 	while (itr)
 	{
 		key = ft_strjoin(((t_env *)itr->content)->key, "=");

--- a/src/env/init_envlist.c
+++ b/src/env/init_envlist.c
@@ -1,30 +1,30 @@
 #include "minishell.h"
 
-t_list	*consume_new_env(t_list *cur, char *str)
+t_list	*consume_new_env(t_list *itr, char *str)
 {
 	t_env	*env;
 
 	env = ft_calloc(1, sizeof(t_env));
 	env->key = ft_strndup(str, ft_strchr(str, '=') - str);
 	env->val = ft_strdup(ft_strchr(str, '=') + 1);
-	cur->next = ft_lstnew(env);
-	return (cur->next);
+	itr->next = ft_lstnew(env);
+	return (itr->next);
 }
 
 t_list	*init_envlist(void)
 {
-	t_list		env_list;
-	t_list		*cur;
+	t_list		*env_list;
+	t_list		*itr;
 	extern char	**environ;
 
-	env_list.next = NULL;
-	cur = &env_list;
+	env_list = ft_lstnew(NULL);
+	itr = env_list;
 	while (*environ)
 	{
-		cur = consume_new_env(cur, *environ);
+		itr = consume_new_env(itr, *environ);
 		environ++;
 	}
-	return (env_list.next);
+	return (env_list);
 }
 
 // int	main(void)

--- a/src/execution/exec_processes.c
+++ b/src/execution/exec_processes.c
@@ -161,7 +161,7 @@ void	exec_child(t_expression *expression, t_process *process, const int cmd_idx,
 	if (is_builtin(cmd))
 		exit(exec_builtin(expression, process, shell_var));
 	fullpath_cmd = get_fullpath_cmd(cmd, shell_var);
-	execve(fullpath_cmd, process->command, get_environ());
+	execve(fullpath_cmd, process->command, get_environ(shell_var));
 	exit(NOCMD);
 }
 

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -17,12 +17,6 @@ void	init_shell_var(t_shell_var *shell_var)
 	shell_var->env_list = init_envlist();
 	shell_var->pwd = NULL;
 	shell_var->oldpwd = NULL;
-	t_list *itr = shell_var->env_list;
-	while (itr)
-	{
-		printf("%s\n", ((t_env *)(itr->content))->key);
-		itr = itr->next;
-	}
 }
 
 void minish_loop(void)


### PR DESCRIPTION
- builtin(env, export, unset)をshell_varに対応
- unsetに対応するためにshell_var->env_listの先頭にダミーを追加
- get_environをshe_varに対応
- init_shell_varのenv_listのprintを削除
close #27 