### PR TITLE
Update pwd oldpwd #33

### DIFF
--- a/includes/shell_var.h
+++ b/includes/shell_var.h
@@ -19,5 +19,6 @@ typedef struct s_env
 t_list		*init_envlist(void);
 char		**get_environ(t_shell_var *shell_var);
 char		*get_env_value(char *key, t_shell_var *shell_var);
+void		set_env_value(char *key, char *val, t_shell_var *shell_var);
 
 #endif

--- a/src/builtin/builtin_cd.c
+++ b/src/builtin/builtin_cd.c
@@ -1,15 +1,40 @@
 #include "minishell.h"
 
+int		builtin_cd_pwd_update(char *path_name, t_shell_var *shell_var)
+{
+	char *relative_path;
+
+	shell_var->oldpwd = shell_var->pwd;
+	if (getcwd(NULL, 0) == NULL)
+	{
+		ft_putendl_fd("cd: error retrieving current directory: \
+			getcwd: cannot access parent directories: \
+			No such file or directory", STDERR_FILENO);
+		relative_path = ft_strjoin("/", path_name);
+		shell_var->pwd = ft_strjoin(shell_var->pwd, relative_path);
+		free(relative_path);
+	}
+	else
+		shell_var->pwd = getcwd(NULL, 0);
+	free(path_name);
+	set_env_value("OLDPWD", shell_var->oldpwd, shell_var);
+	set_env_value("PWD", shell_var->pwd, shell_var);
+	return (0);
+}
+
 int		builtin_cd(t_expression *expression, t_process *process, t_shell_var *shell_var)
 {
 	char	*path_name;
-	char	*relative_path;
-	char	*tmp_path;
 
 	path_name = process->command[1];
 	if (path_name == NULL)
 	{
 		path_name = get_env_value("HOME", shell_var);
+		if (*path_name == '\0')
+		{
+			ft_putendl_fd("cd: HOME not set", STDERR_FILENO);
+			return (1);
+		}
 	}
 	if (chdir(path_name) == -1)
 	{
@@ -19,15 +44,5 @@ int		builtin_cd(t_expression *expression, t_process *process, t_shell_var *shell
 		free(path_name);
 		return (1);
 	}
-	// shell_var->pwd = getcwd(NULL, 0);
-	if (getcwd(NULL, 0) == NULL)
-	{
-		ft_putendl_fd("cd: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory", STDERR_FILENO);
-		relative_path = ft_strjoin("/", path_name);
-		shell_var->pwd = ft_strjoin_free(shell_var->pwd, relative_path, true);
-	}
-	else
-		shell_var->pwd = getcwd(NULL, 0);
-	free(path_name);
-	return (0);
+	return (builtin_cd_pwd_update(path_name, shell_var));
 }

--- a/src/builtin/builtin_export.c
+++ b/src/builtin/builtin_export.c
@@ -35,38 +35,12 @@ static bool validate_args(char *arg)
 	return (valid);
 }
 
-bool	set_env_value(char *arg, t_list *env_list)
-{
-	t_list	*itr;
-	char	*key;
-	char	*val;
-	t_env	*env;
-
-	if (!validate_args(arg))
-		return (false);
-	key = ft_strndup(arg, ft_strchr(arg, '=') - arg);
-	val = ft_strdup(ft_strchr(arg, '=') + 1);
-	itr = env_list->next;
-	while (itr)
-	{
-		if (ft_strcmp(((t_env *)(itr->content))->key, key) == 0)
-		{
-			free(((t_env *)(itr->content))->val);
-			((t_env *)(itr->content))->val = val;
-			return (true);
-		}
-		itr = itr->next;
-	}
-	env = ft_calloc(1, sizeof(t_env));
-	env->key = key;
-	env->val = val;
-	ft_lstadd_back(&env_list, ft_lstnew(env));
-	return (true);
-}
 
 int	builtin_export(t_expression *expression, t_process *process, t_shell_var *shell_var)
 {
 	char	*arg;
+	char	*key;
+	char	*val;
 
 	(void)expression;
 	if (ft_lstsize((t_list *)(process->token_list)) == 1)
@@ -74,8 +48,13 @@ int	builtin_export(t_expression *expression, t_process *process, t_shell_var *sh
 	else
 	{
 		arg = ((t_token *)(process->token_list->next->content))->str;
-		if (!set_env_value(arg, shell_var->env_list))
+		if (!validate_args(arg))
 			return (1);
+		key = ft_strndup(arg, ft_strchr(arg, '=') - arg);
+		val = ft_strdup(ft_strchr(arg, '=') + 1);
+		set_env_value(key, val, shell_var);
+		free(key);
+		free(val);
 	}
 	return (0);
 }

--- a/src/env/set_env_value.c
+++ b/src/env/set_env_value.c
@@ -1,0 +1,28 @@
+#include "minishell.h"
+
+void	set_env_value(char *key, char *val, t_shell_var *shell_var)
+{
+	t_list	*itr;
+	t_env	*env;
+
+	if (ft_strcmp(key, "?") == 0)
+		return ;
+	itr = shell_var->env_list->next;
+	while (itr)
+	{
+		if (ft_strcmp(((t_env *)itr->content)->key, key) == 0)
+		{
+			free(((t_env *)(itr->content))->val);
+			((t_env *)(itr->content))->val = ft_strdup(val);
+			return ;
+		}
+		itr = itr->next;
+	}
+	if (itr == NULL)
+	{
+		env = ft_calloc(1, sizeof(t_env));
+		env->key = ft_strdup(key);
+		env->val = ft_strdup(val);
+		ft_lstadd_back(&(shell_var->env_list), ft_lstnew(env));
+	}
+}


### PR DESCRIPTION
修正点
- set_env_value関数で環境変数の更新を行う．
- cd後に$PWD,$OLDPWDを更新する．
- `$ unset HOME` 後に `$ cd` を実行したときにエラー処理を追加

close #33 