### PR TITLE
Fix leak anlyzer #90

### DIFF
--- a/includes/analyzer.h
+++ b/includes/analyzer.h
@@ -6,7 +6,7 @@
 /*   By: tkoyasak <tkoyasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/03/24 14:07:20 by tkoyasak          #+#    #+#             */
-/*   Updated: 2022/03/26 10:53:17 by tkoyasak         ###   ########.fr       */
+/*   Updated: 2022/03/29 21:39:10 by tkoyasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,7 +38,7 @@ void	lexer_error(char *p, int idx);
 int		parser(t_node **tree, t_list *token_list);
 t_node	*parser_error(t_list **itr, char *str, bool *is_valid);
 t_node	*node_new(t_node_kind kind, t_node *lhs, t_node *rhs);
-bool	consume_node_kind(t_list **itr, char *op);
+bool	consume_node_kind(t_list **itr, char *op, bool *is_valid);
 t_node	*create_proc_node(t_list **itr, bool *is_valid);
 t_node	*convert_to_expr_tree(t_node *tree);
 

--- a/src/analyzer/node_utils.c
+++ b/src/analyzer/node_utils.c
@@ -6,7 +6,7 @@
 /*   By: tkoyasak <tkoyasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/03/25 10:48:30 by tkoyasak          #+#    #+#             */
-/*   Updated: 2022/03/26 10:42:21 by tkoyasak         ###   ########.fr       */
+/*   Updated: 2022/03/29 21:30:18 by tkoyasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,9 +20,9 @@ t_node	*parser_error(t_list **itr, char *str, bool *is_valid)
 		ft_putstr_fd("minishell: syntax error near unexpected token `", \
 			STDERR_FILENO);
 		ft_putstr_fd(str, STDERR_FILENO);
-		ft_putstr_fd("'\n", STDERR_FILENO);
+		ft_putendl_fd("\'", STDERR_FILENO);
+		ft_lstclear(itr, delete_token);
 	}
-	ft_lstclear(itr, delete_token);
 	return (NULL);
 }
 
@@ -38,10 +38,12 @@ t_node	*node_new(t_node_kind kind, t_node *lhs, t_node *rhs)
 }
 
 /*  compare string with operator, and if match consume iterator  */
-bool	consume_node_kind(t_list **itr, char *op)
+bool	consume_node_kind(t_list **itr, char *op, bool *is_valid)
 {
 	t_list	*delete_itr;
 
+	if (!*is_valid)
+		return (false);
 	if (*itr && ft_strcmp(((t_token *)((*itr)->content))->str, op) == 0)
 	{
 		delete_itr = *itr;
@@ -52,21 +54,24 @@ bool	consume_node_kind(t_list **itr, char *op)
 	return (false);
 }
 
-static	int	consume_one_proc(t_list **itr, bool *is_valid)
+/*  consume itr while token kind string or io  */
+static	bool	consume_one_proc(t_list **itr)
 {
+	if (((t_token *)((*itr)->content))->kind != TK_IO && \
+		((t_token *)((*itr)->content))->kind != TK_STRING)
+		return (false);
 	while ((*itr)->next != NULL && \
 		(((t_token *)((*itr)->next->content))->kind == TK_IO || \
 		((t_token *)((*itr)->next->content))->kind == TK_STRING))
 	{
 		if (((t_token *)(*itr)->content)->kind == TK_IO && \
 				((t_token *)((*itr)->next->content))->kind != TK_STRING)
-		{
-			*is_valid = false;
-			return (1);
-		}
+			return (false);
 		*itr = (*itr)->next;
 	}
-	return (0);
+	if (*itr && ((t_token *)((*itr)->content))->kind != TK_STRING)
+		return (false);
+	return (true);
 }
 
 t_node	*create_proc_node(t_list **itr, bool *is_valid)
@@ -74,19 +79,23 @@ t_node	*create_proc_node(t_list **itr, bool *is_valid)
 	t_node	*node;
 	t_list	*tail;
 
+	if (!*is_valid || !*itr)
+		return (NULL);
 	node = ft_xcalloc(1, sizeof(t_node));
 	node->kind = ND_PROC;
 	node->token_list = *itr;
-	if (consume_one_proc(itr, is_valid))
-		return (node);
-	tail = *itr;
-	*itr = tail->next;
-	tail->next = NULL;
-	if (((t_token *)tail->content)->kind == TK_IO || \
-		(*itr && ((t_token *)(*itr)->content)->kind == TK_L_PAREN))
+	if (consume_one_proc(itr))
 	{
-		parser_error(itr, ((t_token *)tail->content)->str, is_valid);
+		tail = *itr;
+		*itr = tail->next;
+		tail->next = NULL;
 		return (node);
 	}
-	return (node);
+	else
+	{
+		parser_error(&(node->token_list), \
+				((t_token *)(*itr)->content)->str, is_valid);
+		delete_node(node);
+		return (NULL);
+	}
 }

--- a/src/analyzer/parser.c
+++ b/src/analyzer/parser.c
@@ -6,7 +6,7 @@
 /*   By: tkoyasak <tkoyasak@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/03/25 10:48:38 by tkoyasak          #+#    #+#             */
-/*   Updated: 2022/03/26 10:42:48 by tkoyasak         ###   ########.fr       */
+/*   Updated: 2022/03/29 21:38:45 by tkoyasak         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,46 +18,38 @@ static t_node	*create_subshell_tree(t_list **itr, bool *is_valid)
 {
 	t_node	*node;
 
-	if (consume_node_kind(itr, "("))
+	if (consume_node_kind(itr, "(", is_valid))
 	{
-		node = ft_xcalloc(1, sizeof(t_node));
-		node->kind = ND_SUBSHELL;
-		node->lhs = create_astree(itr, is_valid);
-		if (consume_node_kind(itr, ")") == false)
+		node = node_new(ND_SUBSHELL, create_astree(itr, is_valid), NULL);
+		if (!consume_node_kind(itr, ")", is_valid))
 		{
 			parser_error(itr, "(", is_valid);
 			return (node);
 		}
 		return (node);
 	}
-	if (*itr == NULL)
-		return (NULL);
-	else if (((t_token *)((*itr)->content))->kind == TK_STRING || \
-		((t_token *)((*itr)->content))->kind == TK_IO)
-		return (create_proc_node(itr, is_valid));
-	else if (((t_token *)((*itr)->content))->kind == TK_DELIM)
-		return (parser_error(itr, ((t_token *)((*itr)->content))->str, \
-			is_valid));
-	else
-		return (NULL);
+	return (create_proc_node(itr, is_valid));
 }
 
 static t_node	*create_sub_astree(t_list **itr, bool *is_valid)
 {
 	t_node	*node;
-	t_node	*r_node;
+	t_node	*rhs;
 
-	if (*itr == NULL)
+	if (!*is_valid || !*itr)
 		return (NULL);
 	node = create_subshell_tree(itr, is_valid);
 	while (*is_valid)
 	{
-		if (consume_node_kind(itr, "|"))
+		if (consume_node_kind(itr, "|", is_valid))
 		{
-			r_node = create_subshell_tree(itr, is_valid);
-			if (r_node == NULL)
-				return (parser_error(itr, "|", is_valid));
-			node = node_new(ND_PIPE, node, r_node);
+			rhs = create_subshell_tree(itr, is_valid);
+			if (rhs == NULL)
+			{
+				parser_error(itr, "|", is_valid);
+				return (node);
+			}
+			node = node_new(ND_PIPE, node, rhs);
 		}
 		else
 			return (node);
@@ -68,19 +60,19 @@ static t_node	*create_sub_astree(t_list **itr, bool *is_valid)
 /*  create abstract syntax tree  */
 static t_node	*create_astree(t_list **itr, bool *is_valid)
 {
-	t_node		*node;
+	t_node	*node;
 
 	if (*itr == NULL)
 		return (NULL);
 	node = create_sub_astree(itr, is_valid);
 	while (*is_valid)
 	{
-		if (consume_node_kind(itr, ";"))
+		if (consume_node_kind(itr, ";", is_valid))
 			node = node_new(ND_SEMICOLON, node, \
 				create_sub_astree(itr, is_valid));
-		else if (consume_node_kind(itr, "&&"))
+		else if (consume_node_kind(itr, "&&", is_valid))
 			node = node_new(ND_DAND, node, create_sub_astree(itr, is_valid));
-		else if (consume_node_kind(itr, "||"))
+		else if (consume_node_kind(itr, "||", is_valid))
 			node = node_new(ND_DPIPE, node, create_sub_astree(itr, is_valid));
 		else
 			return (node);


### PR DESCRIPTION
- parserのエラーハンドルをリファクタしました．
- is_validがfalseのときは `consume_node_kind` や `create_proc_node` は何もせずすぐにリターンしています．
- テスター２つは結果は同じでしたが，リークチェックは大体しかできていません．
- lexerのカッコのチェック `validate_syntax` でエラーに該当するトークンを出力するようにしました．