### PR TITLE
fix: commandがない時のleak

### DIFF
--- a/includes/executor.h
+++ b/includes/executor.h
@@ -38,6 +38,7 @@ void		exec_child(t_expr *expr, t_proc *proc, \
 						int cmd_idx, t_sh_var *sh_var);
 void		dup2_func(t_expr *expr, t_proc *proc, const int cmd_idx);
 void		close_func(t_expr *expr, t_proc *proc, const int cmd_idx);
+int			path_error(char *fullpath_cmd);
 
 /*  io  */
 t_io_kind	get_io_kind(char *redirect_str);

--- a/src/executor/exec_child.c
+++ b/src/executor/exec_child.c
@@ -6,13 +6,13 @@
 /*   By: jkosaka <jkosaka@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/03/24 11:12:27 by jkosaka           #+#    #+#             */
-/*   Updated: 2022/03/25 17:38:29 by jkosaka          ###   ########.fr       */
+/*   Updated: 2022/03/29 22:09:06 by jkosaka          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-static int	path_error(char *fullpath_cmd)
+int	path_error(char *fullpath_cmd)
 {
 	ft_putstr_fd("minishell: ", STDERR_FILENO);
 	ft_putstr_fd(fullpath_cmd, STDERR_FILENO);

--- a/src/executor/exec_single_process.c
+++ b/src/executor/exec_single_process.c
@@ -6,11 +6,36 @@
 /*   By: jkosaka <jkosaka@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/03/24 11:16:41 by jkosaka           #+#    #+#             */
-/*   Updated: 2022/03/28 21:59:02 by jkosaka          ###   ########.fr       */
+/*   Updated: 2022/03/29 22:49:53 by jkosaka          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
+
+/*  execute single child process  */
+static void	exec_single_child(t_expr *expr, t_proc *proc, int cmd_idx, t_sh_var *sh_var)
+{
+	char		*cmd;
+	char		*fullpath_cmd;
+	struct stat	buf;
+
+	signal(SIGINT, SIG_DFL);
+	signal(SIGQUIT, SIG_DFL);
+	cmd = ((t_token *)(proc->token_list->content))->str;
+	dup2_func(expr, proc, cmd_idx);
+	close_func(expr, proc, cmd_idx);
+	if (g_exit_status)
+		exit(1);
+	fullpath_cmd = get_fullpath_cmd(cmd, sh_var);
+	if (fullpath_cmd)
+	{
+		safe_func(stat(fullpath_cmd, &buf));
+		if ((buf.st_mode & S_IFMT) == S_IFDIR)
+			exit(path_error(fullpath_cmd));
+	}
+	execve(fullpath_cmd, proc->command, get_environ(sh_var));
+	exit(NO_CMD);
+}
 
 /*  execute single external command  */
 int	exec_single_external(t_expr *expr, t_proc *proc, t_sh_var *sh_var)
@@ -20,10 +45,15 @@ int	exec_single_external(t_expr *expr, t_proc *proc, t_sh_var *sh_var)
 
 	proc_list = expr->proc_list;
 	proc = proc_list->content;
+	if (ft_strcmp(proc->command[0], "") == 0)
+	{
+		free(proc->command[0]);
+		return (g_exit_status);
+	}
 	signal(SIGINT, SIG_IGN);
 	expr->pid[0] = safe_func(fork());
 	if (expr->pid[0] == 0)
-		exec_child(expr, proc, 0, sh_var);
+		exec_single_child(expr, proc, 0, sh_var);
 	safe_func(waitpid(expr->pid[0], &wstatus, WUNTRACED));
 	last_proc_signal(wstatus);
 	signal(SIGINT, sigint_handler);


### PR DESCRIPTION
close #92 
exec_single_childという関数を作り、またexec_single_externalでfree(proc->command[0]);
一つだけfreeするという方法をとってなんとかleakは治っていますが、もう少し良い方法があるかもしれません。